### PR TITLE
Add support for OpenVPN status file version 2 format

### DIFF
--- a/libnss_openvpn.c
+++ b/libnss_openvpn.c
@@ -72,11 +72,11 @@ enum nss_status _nss_openvpn_gethostbyname_r (
 
             int in = 0;
             while (fgets(strbuf, BUFLEN, fh)) {
-                if (strncmp(strbuf, "Virtual Address", 10) == 0) {
+                if (strncmp(strbuf, "Virtual Address", 10) == 0 || strstr(strbuf, "ROUTING_TABLE,Virtual Address") != NULL) {
                     in = 1;
                     continue;
                 }
-                if (strncmp(strbuf, "GLOBAL STATS", 10) == 0) {
+                if (strncmp(strbuf, "GLOBAL STATS", 10) == 0 || strncmp(strbuf, "GLOBAL_STATS", 12) == 0) {
                     in = 0;
                     continue;
                 }
@@ -84,7 +84,7 @@ enum nss_status _nss_openvpn_gethostbyname_r (
                     continue;
                 }
 
-                current_ip=strbuf;
+                current_ip = (strncmp(strbuf, "ROUTING_TABLE,", 14) == 0) ? strbuf + 14 : strbuf;
                 t = strchr(current_ip, ',');
                 if (t == NULL) {
                     continue;


### PR DESCRIPTION
Extends parsing to handle both version 1 and version 2 status files:
- Detects HEADER,ROUTING_TABLE,Virtual Address headers (version 2)
- Handles GLOBAL_STATS terminator format (version 2)
- Strips ROUTING_TABLE, prefix from data lines (version 2)
- Maintains backward compatibility with version 1 format

Fibery link: https://balena.fibery.io/search/DMrAW#Work/Project/Make-libnss-compatible-with-openvpn-status-version-2-1635

Change-type: patch